### PR TITLE
Fix declaration of DefaultController::beforeAction

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -32,7 +32,7 @@ class DefaultController extends Controller
     /**
      * {@inheritdoc}
      */
-    public function beforeAction($action): bool
+    public function beforeAction(\yii\base\Action $action): bool
     {
         Yii::getApp()->response->format = Response::FORMAT_HTML;
         return parent::beforeAction($action);


### PR DESCRIPTION
PHP Warning 'yii\exceptions\ErrorException' with message 'Declaration of yii\gii\controllers\DefaultController::beforeAction(yii\helpers\Yii\base\Action $action): bool should be compatible with yii\web\Controller::beforeAction(yii\base\Action $action): bool'.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | -