### PR TITLE
Remove generators from params

### DIFF
--- a/config/params.php
+++ b/config/params.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Yiisoft\Yii\Gii\Command\ControllerCommand;
-use Yiisoft\Yii\Gii\Generator as Generators;
 
 return [
     'yiisoft/yii-debug' => [
@@ -24,16 +23,7 @@ return [
     'yiisoft/yii-gii' => [
         'enabled' => true,
         'allowedIPs' => ['127.0.0.1', '::1'],
-        'generators' => [
-            [
-                'class' => Generators\Controller\Generator::class,
-                'parameters' => [],
-            ],
-            [
-                'class' => Generators\ActiveRecord\Generator::class,
-                'parameters' => [],
-            ],
-        ],
+        'generators' => [],
         'parameters' => [
             'templates' => [],
         ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Instances of generators creates before create `Gii` instance (see config `di.php`). But generators contain dependencies, which may not exist in app. It's leads to errors.

For example, `ActiveRecord\Generator` require `ConnectionInterface`, but demo app don't use Yii DB.