### PR TITLE
Fix #131: Regex correction for table name

### DIFF
--- a/src/Generator/ActiveRecord/Command.php
+++ b/src/Generator/ActiveRecord/Command.php
@@ -24,7 +24,7 @@ final class Command extends AbstractGeneratorCommand
         private readonly string $namespace = 'App\\Model',
         #[Required]
         #[Regex(
-            pattern: '/^(?:[a-z][a-z0-9]*)(?:\\\\[a-z][a-z0-9]*)*$/i',
+            pattern: '/^[a-z_][a-z0-9_]*$/i',
             message: 'Invalid table name'
         )]
         #[TableExistsRule]


### PR DESCRIPTION
Fixes #131

validates table names (letters, digits, underscore)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
